### PR TITLE
Mock HTTP requests in tests

### DIFF
--- a/tests/TwsmsSenderTest.php
+++ b/tests/TwsmsSenderTest.php
@@ -4,21 +4,43 @@ use TwsmsSender\TwsmsSender;
 
 class TwsmsSenderTest extends TestCase
 {
-	protected $username;
-	protected $password;
+        protected $username;
+        protected $password;
+
+        private function createMockSender(array $responses)
+        {
+            $mock = $this->getMockBuilder(TwsmsSender::class)
+                ->setConstructorArgs([$this->username, $this->password])
+                ->onlyMethods(['getContent'])
+                ->getMock();
+
+            $mock->method('getContent')
+                ->willReturnOnConsecutiveCalls(...$responses);
+
+            return $mock;
+        }
 
 	protected function setUp()
     {
-    	$config= parse_ini_file("twsms.ini",true) ;     	
-    	$this->username = $config['twsms']['username'];
-    	$this->password = $config['twsms']['password'];
+        $config = [];
+        if (file_exists('twsms.ini')) {
+            $config = parse_ini_file('twsms.ini', true);
+        } elseif (file_exists('twsms.ini.bak')) {
+            $config = parse_ini_file('twsms.ini.bak', true);
+        }
+
+        $this->username = getenv('TWSMS_USERNAME') ?: ($config['twsms']['username'] ?? 'twsms');
+        $this->password = getenv('TWSMS_PASSWORD') ?: ($config['twsms']['password'] ?? 'pass');
     }
 
     public function testQueryPoint()
     {
-        $TwsmsSender = new TwSmsSender($this->username,$this->password);
-        $result = $TwsmsSender->querypoint();        
-        $this->assertTrue($result['point'] > 1 );
+        $sender = $this->createMockSender([
+            '<result><point>10</point><code>00000</code><text>Success</text></result>'
+        ]);
+
+        $result = $sender->querypoint();
+        $this->assertTrue($result['point'] > 1);
     }
     // //17499786
     // public function testSendQueryAndDel()
@@ -31,36 +53,44 @@ class TwsmsSenderTest extends TestCase
 
     public function testSendQueryAndDel()
     {
-        $TwsmsSender = new TwSmsSender($this->username,$this->password);
+        $sender = $this->createMockSender([
+            '<result><msgid>1234</msgid><code>00000</code><text>Success</text><statustext>OK</statustext></result>',
+            '<result><point>0</point><code>00000</code><text>Success</text></result>',
+            '<result><point>0</point><code>00000</code><text>Success</text></result>'
+        ]);
 
-        $result = $TwsmsSender->send('0975000000', 'test sms message', '201612311256' );
+        $result = $sender->send('0975000000', 'test sms message', '201612311256' );
         $this->assertNotNull($result['id']);
         $this->assertEquals('Success', $result['text']);
-        
-        $result_que = $TwsmsSender->query('0975000000' , $result['id'] );
-        $this->assertEquals('Success' , $result_que['text']);   
 
-        $result_del = $TwsmsSender->deltime('0975000000' , $result['id'] );
-        $this->assertEquals('Success' , $result_del['text']);   
+        $result_que = $sender->query('0975000000' , $result['id'] );
+        $this->assertEquals('Success' , $result_que['text']);
+
+        $result_del = $sender->deltime('0975000000' , $result['id'] );
+        $this->assertEquals('Success' , $result_del['text']);
 
     }
 	public function testSendAndQuery()
     {
-        $TwsmsSender = new TwSmsSender($this->username,$this->password);
-        $result = $TwsmsSender->send('0975000000', 'test sms message', '201612312359' );
+        $sender = $this->createMockSender([
+            '<result><msgid>5678</msgid><code>00000</code><text>Success</text><statustext>OK</statustext></result>'
+        ]);
+        $result = $sender->send('0975000000', 'test sms message', '201612312359' );
 
         $this->assertNotNull($result['id']);
         $this->assertEquals('Success', $result['text']);
         $this->assertEquals('0975000000', $result['recipient']);
         $this->assertEquals('test sms message', $result['body']);        
 
-        // $result = $TwsmsSender->query('0975000000', $result['id'] );
+        // $result = $sender->query('0975000000', $result['id'] );
     }
 
     public function testSendDirect()
     {
-        $TwsmsSender = new TwSmsSender($this->username,$this->password);
-        $result = $TwsmsSender->send('0975000000', 'test sms message', null);
+        $sender = $this->createMockSender([
+            '<result><msgid>91011</msgid><code>00000</code><text>Success</text><statustext>OK</statustext></result>'
+        ]);
+        $result = $sender->send('0975000000', 'test sms message', null);
 
         $this->assertNotNull($result['id']);
         $this->assertEquals('Success', $result['text']);     


### PR DESCRIPTION
## Summary
- read API credentials from env vars in unit tests
- add helper to mock network requests
- update tests to not hit real API endpoints

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b99f5e930832db20c027f7f7356bd