### PR TITLE
Add custom InvalidCredentialsException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "phpunit/phpunit": "4.*"
     },
     "autoload": {
-        "psr-0": { "TwsmsSender": "src/" }
+        "psr-4": {
+            "TwsmsSender\\": "src/",
+            "TwsmsSender\\Exception\\": "src/TwsmsSender/Exception/"
+        }
     }
 }

--- a/src/TwsmsSender/Exception/InvalidCredentialsException.php
+++ b/src/TwsmsSender/Exception/InvalidCredentialsException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TwsmsSender\Exception;
+
+class InvalidCredentialsException extends \InvalidArgumentException
+{
+}
+

--- a/tests/TwsmsSenderTest.php
+++ b/tests/TwsmsSenderTest.php
@@ -63,7 +63,14 @@ class TwsmsSenderTest extends TestCase
         $result = $TwsmsSender->send('0975000000', 'test sms message', null);
 
         $this->assertNotNull($result['id']);
-        $this->assertEquals('Success', $result['text']);     
+        $this->assertEquals('Success', $result['text']);
+    }
+
+    public function testInvalidCredentialsThrowsException()
+    {
+        $this->expectException(\TwsmsSender\Exception\InvalidCredentialsException::class);
+        new TwSmsSender(null, null);
     }
 
 }
+


### PR DESCRIPTION
## Summary
- create `InvalidCredentialsException`
- autoload Exception namespace via PSR-4
- add unit test for invalid credentials

## Testing
- `composer dump-autoload` *(fails: command not found)*
- `vendor/bin/phpunit -c phpunit.xml.dist tests` *(fails: No such file)*
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b98fc3a7c832da3459778a4f62128